### PR TITLE
Toggle next ingredient step highlight with space bar

### DIFF
--- a/src/app/recipe-detail/recipe-detail.component.ts
+++ b/src/app/recipe-detail/recipe-detail.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, HostListener, Input } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { Location } from '@angular/common';
 import { Recipe } from '../models/recipe';
@@ -22,6 +22,12 @@ export class RecipeDetailComponent {
 
   ngOnInit(): void {
     this.setRecipe();
+  }
+
+  @HostListener('window:keydown.space', ['$event'])
+  onSpacebar(event: KeyboardEvent) {
+    event.preventDefault(); // prevent default space bar 'scroll down' browser behavior
+    this.nextStep();
   }
 
   nextStep(): void{


### PR DESCRIPTION
Added toggling of step highlighting with the space bar. Two things of note:

- Listening for a keydown on just an html element is not enough. We need to respond to any keydown in the entire document.  We use the [`HostListener`](https://angular.io/api/core/HostListener) in Angular for this.
- By default, pressing the space bar in a browser will cause the page to scroll down. We want to override this behaviour and prevent that from happening. To accomplish this, we use [`event.preventDefault`](https://developer.mozilla.org/en-US/docs/Web/API/Event/preventDefault).